### PR TITLE
:bug: Update base and branch in GitHub workflow

### DIFF
--- a/.github/workflows/stats-commit-count.yaml
+++ b/.github/workflows/stats-commit-count.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          base: 'ReleaseMaster'
-          branch: 'Pre-release'
+          base: 'Pre-release'
+          branch: 'ReleaseMaster'
           title: 'Update commit count'
           body: 'This is an auto-generated pull request to update commit count.'


### PR DESCRIPTION
Swapped the 'base' and 'branch' fields in stats-commit-count.yaml. Now 'base' is 'Pre-release' and 'branch' is 'ReleaseMaster', adjusting the workflow of the auto-generated pull request for updating the commit count.