### PR TITLE
:bug: Disable automatic pull request creation in stats-commit-count w…

### DIFF
--- a/.github/workflows/stats-commit-count.yaml
+++ b/.github/workflows/stats-commit-count.yaml
@@ -47,11 +47,11 @@ jobs:
           git commit -m ":wrench: Update commit count" || echo "No changes to commit"
           git push origin Pre-release
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: 'Pre-release'
-          branch: 'ReleaseMaster'
-          title: 'Update commit count'
-          body: 'This is an auto-generated pull request to update commit count.'
+#      - name: Create Pull Request
+#        uses: peter-evans/create-pull-request@v3
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          base: 'Pre-release'
+#          branch: 'ReleaseMaster'
+#          title: 'Update commit count'
+#          body: 'This is an auto-generated pull request to update commit count.'


### PR DESCRIPTION
…orkflow

The change in code has commented out the steps in the GitHub workflow that auto-generates a pull request to update the commit count. This means committing will now only update the pre-release branch and no automatic pull request will be created towards the ReleaseMaster branch.