### PR TITLE
:label: Add git pull action in commits count workflow

### DIFF
--- a/.github/workflows/stats-commit-count.yaml
+++ b/.github/workflows/stats-commit-count.yaml
@@ -43,6 +43,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git checkout -b Pre-release || git checkout Pre-release
+          git pull
           git add conf/publish/gitcommitrc
           git commit -m ":wrench: Update commit count" || echo "No changes to commit"
           git push origin Pre-release


### PR DESCRIPTION
A git pull action has been added to the stats-commit-count.yaml GitHub workflow. This ensures that the bot's local repository is updated with the latest changes before performing a commit and push to the Pre-release branch.