### PR TITLE
:construction_worker: Modify trigger conditions in code-quality workflow

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -7,12 +7,11 @@
 name: Qodana Scan
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches: # Specify your branches here
       - "ReleaseMaster"
     paths:
-      - "*"
+      - "**"
 
 jobs:
   qodana:


### PR DESCRIPTION
Updated the triggering conditions in the 'Qodana Scan' workflow inside GitHub workflows for the project. Removed 'pull_request' and modified file paths for 'push' event, making it more specific using double asterisks '**', which matches any number of directory levels.