### PR TITLE
:art: Clean up whitespace in postgresql.py

### DIFF
--- a/fairylandfuture/modules/databases/postgresql.py
+++ b/fairylandfuture/modules/databases/postgresql.py
@@ -53,10 +53,10 @@ class PostgreSQLConnector:
         self._database = database
         self._schema = schema
         self._dsn = f"host={self._host} port={self._port} user={self._user} password={self._password} dbname={self._database}"
-        
+
         if self._schema:
             self._dsn += f" options='-c search_path={self._schema}'"
-            
+
         self.connect: CustomPostgreSQLConnect = self.__connect()
         self.cursor: CustomPostgreSQLCursor = self.connect.cursor()
 


### PR DESCRIPTION
Extraneous white spaces within the postgresql.py file were removed for a cleaner and more readable code. This change specifically targets the accurate generation of the Data Source Name (_dsn).