### PR TITLE
:sparkles: Add ResponseStructure and initial tests

### DIFF
--- a/fairylandfuture/core/superclass/structures.py
+++ b/fairylandfuture/core/superclass/structures.py
@@ -8,16 +8,32 @@
 """
 
 import json
-from dataclasses import asdict, dataclass
+
+from dataclasses import dataclass, asdict, astuple
+
+from typing import Dict, Any, Tuple
 
 
 @dataclass(frozen=True)
 class BaseStructure:
 
     @property
-    def __dict__(self):
+    def asdict(self) -> Dict[str, Any]:
         return asdict(self)
 
     @property
-    def json(self):
-        return json.dumps(self.__dict__)
+    def astuple(self) -> Tuple[Any, ...]:
+        return astuple(self)
+
+    @property
+    def string(self) -> str:
+        return json.dumps(self.asdict, separators=(",", ":"), ensure_ascii=False)
+
+    def to_dict(self, /, *, ignorenone: bool = False) -> Dict[str, Any]:
+        if ignorenone:
+            return {k: v for k, v in self.asdict.items() if v is not None}
+        else:
+            return self.asdict
+
+    def to_jsonstring(self, /, *, ignorenone: bool = False) -> str:
+        return json.dumps(self.to_dict(ignorenone=ignorenone), separators=(",", ":"), ensure_ascii=False)

--- a/fairylandfuture/structures/general/__init__.py
+++ b/fairylandfuture/structures/general/__init__.py
@@ -1,0 +1,8 @@
+# coding: utf-8
+"""
+@software: PyCharm
+@author: Lionel Johnson
+@contact: https://fairy.host
+@organization: https://github.com/FairylandFuture
+@since: 2024-08-14 17:01:45 UTC+08:00
+"""

--- a/fairylandfuture/structures/general/api.py
+++ b/fairylandfuture/structures/general/api.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+"""
+@software: PyCharm
+@author: Lionel Johnson
+@contact: https://fairy.host
+@organization: https://github.com/FairylandFuture
+@since: 2024-08-14 17:02:11 UTC+08:00
+"""
+
+from dataclasses import dataclass, field
+
+from fairylandfuture.core.superclass.structures import BaseStructure
+
+from typing import MutableSequence, Sequence, MutableMapping, Mapping, Union
+
+
+@dataclass(frozen=True)
+class ResponseStructure(BaseStructure):
+    code: int = field(default=None)
+    message: str = field(default=None)
+    data: Union[MutableSequence, Sequence, MutableMapping, Mapping] = field(default=None)
+
+    def __default_message(self, _k):
+        response_code_mapping = {
+            100: "Continue",
+            101: "Switching Protocols",
+            102: "Processing",
+            200: "OK",
+            201: "Created",
+            202: "Accepted",
+            203: "Non-Authoritative Information",
+            204: "No Content",
+            205: "Reset Content",
+            206: "Partial Content",
+            207: "Multi-Status",
+            300: "Multiple Choices",
+            301: "Moved Permanently",
+            302: "Found",
+            303: "See Other",
+            304: "Not Modified",
+            307: "Temporary Redirect",
+            308: "Permanent Redirect",
+            400: "Bad Request",
+            401: "Unauthorized",
+            402: "Payment Required",
+            403: "Forbidden",
+            404: "Not Found",
+            405: "Method Not Allowed",
+            406: "Not Acceptable",
+            407: "Proxy Authentication Required",
+            408: "Request Timeout",
+            409: "Conflict",
+            410: "Gone",
+            411: "Length Required",
+            412: "Precondition Failed",
+            413: "Payload Too Large",
+            414: "URI Too Long",
+            415: "Unsupported Media Type",
+            416: "Range Not Satisfiable",
+            417: "Expectation Failed",
+            418: "I'm a teapot",
+            421: "Misdirected Request",
+            422: "Unprocessable Entity",
+            423: "Locked",
+            424: "Failed Dependency",
+            425: "Too Early",
+            426: "Upgrade Required",
+            428: "Precondition Required",
+            429: "Too Many Requests",
+            431: "Request Header Fields Too Large",
+            451: "Unavailable For Legal Reasons",
+            500: "Internal Server Error",
+            501: "Not Implemented",
+            502: "Bad Gateway",
+            503: "Service Unavailable",
+            504: "Gateway Timeout",
+            505: "HTTP Version Not Supported",
+            506: "Variant Also Negotiates",
+            507: "Insufficient Storage",
+            508: "Loop Detected",
+            510: "Not Extended",
+            511: "Network Authentication Required",
+        }
+        return response_code_mapping.get(_k, "Internal Server Error")
+
+    def __post_init__(self):
+        if self.code and not self.message:
+            object.__setattr__(self, "message", self.__default_message(self.code))
+
+    def __str__(self):
+        return self.string

--- a/test/devunit/20240814/_test.py
+++ b/test/devunit/20240814/_test.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+"""
+@software: PyCharm
+@author: Lionel Johnson
+@contact: https://fairy.host
+@organization: https://github.com/FairylandFuture
+@since: 2024-08-14 17:13:15 UTC+08:00
+"""
+
+from fairylandfuture.structures.general.api import ResponseStructure
+
+
+if __name__ == "__main__":
+    data = {"key": '["asdsa"]'}
+    response = ResponseStructure(code=200, data=data)
+    d = response.asdict
+    d.update(code=2000)
+    print(repr(response), repr(response.to_dict(ignorenone=True)), repr(d))


### PR DESCRIPTION
Introduced a new `ResponseStructure` dataclass in `fairylandfuture/structures/general/api.py` for handling API responses. Additionally, set up a basic test script in `test/devunit/20240814/_test.py` to verify its functionality.